### PR TITLE
Fixes to make Espressif IDF work (with artifacts for dependencies)

### DIFF
--- a/ce/ce/archivers/ZipUnpacker.ts
+++ b/ce/ce/archivers/ZipUnpacker.ts
@@ -49,6 +49,19 @@ export class ZipUnpacker extends Unpacker {
 
       const openedFile = await archiveUri.openFile();
       const zipFile = await ZipFile.read(openedFile);
+      if (options.strip === -1) {
+        // when strip == -1, strip off all common folders off the front of the file names
+        options.strip = 0;
+        const folders = [...zipFile.folders.keys()].sort((a, b) => a.length - b.length);
+        const files = [...zipFile.files.keys()];
+        for (const folder of folders) {
+          if (files.all((filename) => filename.startsWith(folder))) {
+            options.strip = folder.split('/').length - 1;
+            continue;
+          }
+          break;
+        }
+      }
 
       const archiveProgress = new PercentageScaler(0, zipFile.files.size);
       this.progress(0);

--- a/ce/ce/archivers/git.ts
+++ b/ce/ce/archivers/git.ts
@@ -16,13 +16,13 @@ export interface CloneOptions {
 export class Git {
   #session: Session;
   #toolPath: string;
-  #targetFolder: string;
+  #targetFolder: Uri;
   #environment: NodeJS.ProcessEnv;
 
   constructor(session: Session, toolPath: string, environment: NodeJS.ProcessEnv, targetFolder: Uri) {
     this.#session = session;
     this.#toolPath = toolPath;
-    this.#targetFolder = targetFolder.fsPath;
+    this.#targetFolder = targetFolder;
     this.#environment = environment;
   }
 
@@ -40,7 +40,7 @@ export class Git {
     const result = await execute(this.#toolPath, [
       'clone',
       remote,
-      this.#targetFolder,
+      this.#targetFolder.fsPath,
       options.recursive ? '--recursive' : '',
       options.depth ? `--depth=${options.depth}` : '',
       '--progress'
@@ -48,7 +48,6 @@ export class Git {
       env: this.#environment,
       onStdErrData: (chunk) => {
         // generate progress events
-        // this.#session.channels.debug(chunk.toString());
         const regex = /\s([0-9]*?)%/;
         chunk.toString().split(/^/gim).map((x: string) => x.trim()).filter((each: any) => each).forEach((line: string) => {
           const match_array = line.match(regex);
@@ -59,11 +58,7 @@ export class Git {
       }
     });
 
-    if (result.code) {
-      return false;
-    }
-
-    return true;
+    return result.code === 0 ? true : false;
   }
 
   /**
@@ -74,24 +69,20 @@ export class Git {
    * @returns Boolean representing whether the execution was completed without error, this is not necessarily
    *  a guarantee that the fetch did what we expected.
    */
-  async fetch(remoteName: string, events: Partial<InstallEvents>, options: { commit?: string, recursive?: boolean, depth?: number } = {}) {
+  async fetch(remoteName: string, events: Partial<InstallEvents>, options: { commit?: string, depth?: number } = {}) {
     const result = await execute(this.#toolPath, [
       '-C',
-      this.#targetFolder,
+      this.#targetFolder.fsPath,
       'fetch',
       remoteName,
       options.commit ? options.commit : '',
-      options.recursive ? '--recurse-submodules' : '',
       options.depth ? `--depth=${options.depth}` : ''
     ], {
-      env: this.#environment
+      env: this.#environment,
+      cwd: this.#targetFolder.fsPath
     });
 
-    if (result.code) {
-      return false;
-    }
-
-    return true;
+    return result.code === 0 ? true : false;
   }
 
   /**
@@ -105,19 +96,26 @@ export class Git {
   async checkout(events: Partial<InstallEvents>, options: { commit?: string } = {}) {
     const result = await execute(this.#toolPath, [
       '-C',
-      this.#targetFolder,
+      this.#targetFolder.fsPath,
       'checkout',
       options.commit ? options.commit : ''
     ], {
-      env: this.#environment
+      env: this.#environment,
+      cwd: this.#targetFolder.fsPath,
+      onStdErrData: (chunk) => {
+        // generate progress events
+        const regex = /\s([0-9]*?)%/;
+        chunk.toString().split(/^/gim).map((x: string) => x.trim()).filter((each: any) => each).forEach((line: string) => {
+          const match_array = line.match(regex);
+          if (match_array !== null) {
+            events.heartbeat?.(line.trim());
+          }
+        });
+      }
     });
-
-    if (result.code) {
-      return false;
-    }
-
-    return true;
+    return result.code === 0 ? true : false;
   }
+
 
   /**
    * Performs a reset on the git repo.
@@ -129,19 +127,123 @@ export class Git {
   async reset(events: Partial<InstallEvents>, options: { commit?: string, recurse?: boolean, hard?: boolean } = {}) {
     const result = await execute(this.#toolPath, [
       '-C',
-      this.#targetFolder,
+      this.#targetFolder.fsPath,
       'reset',
       options.commit ? options.commit : '',
       options.recurse ? '--recurse-submodules' : '',
       options.hard ? '--hard' : ''
     ], {
-      env: this.#environment
+      env: this.#environment,
+      cwd: this.#targetFolder.fsPath,
+      onStdErrData: (chunk) => {
+        // generate progress events
+        const regex = /\s([0-9]*?)%/;
+        chunk.toString().split(/^/gim).map((x: string) => x.trim()).filter((each: any) => each).forEach((line: string) => {
+          const match_array = line.match(regex);
+          if (match_array !== null) {
+            events.heartbeat?.(line.trim());
+          }
+        });
+      }
     });
+    return result.code === 0 ? true : false;
+  }
 
-    if (result.code) {
-      return false;
+
+  /**
+   * Initializes a folder on disk to be a git repository
+   * @returns true if the initialization was successful, false otherwise.
+   */
+  async init() {
+    if (! await this.#targetFolder.exists()) {
+      await this.#targetFolder.createDirectory();
     }
 
-    return true;
+    if (! await this.#targetFolder.isDirectory()) {
+      throw new Error(`${this.#targetFolder.fsPath} is not a directory.`);
+    }
+
+    const result = await execute(this.#toolPath, ['init'], {
+      env: this.#environment,
+      cwd: this.#targetFolder.fsPath
+    });
+
+    return result.code === 0 ? true : false;
+  }
+
+  /**
+   * Adds a remote location to the git repo.
+   * @param name the name of the remote to add.
+   * @param location the location of the remote to add.
+   * @returns true if the addition was successful, false otherwise.
+   */
+  async addRemote(name: string, location: Uri) {
+    const result = await execute(this.#toolPath, [
+      '-C',
+      this.#targetFolder.fsPath,
+      'remote',
+      'add',
+      name,
+      location.toString()
+    ], {
+      env: this.#environment,
+      cwd: this.#targetFolder.fsPath
+    });
+
+    return result.code === 0 ? true : false;
+  }
+
+  /**
+   * updates submodules in a git repository
+   * @param events Events to possibly track progress.
+   * @param options Options to control how the submodule update is called.
+   * @returns true if the update was successful, false otherwise.
+   */
+  async updateSubmodules(events: Partial<InstallEvents>, options: { init?: boolean, recursive?: boolean, depth?: number } = {}) {
+    const result = await execute(this.#toolPath, [
+      '-C',
+      this.#targetFolder.fsPath,
+      'submodule',
+      'update',
+      options.init ? '--init' : '',
+      options.depth ? `--depth=${options.depth}` : '',
+      options.recursive ? '--recursive' : '',
+    ], {
+      env: this.#environment,
+      cwd: this.#targetFolder.fsPath,
+      onStdErrData: (chunk) => {
+        // generate progress events
+        const regex = /\s([0-9]*?)%/;
+        chunk.toString().split(/^/gim).map((x: string) => x.trim()).filter((each: any) => each).forEach((line: string) => {
+          const match_array = line.match(regex);
+          if (match_array !== null) {
+            events.heartbeat?.(line.trim());
+          }
+        });
+      }
+    });
+
+    return result.code === 0 ? true : false;
+  }
+
+  /**
+   * sets a git configuration value in the repo.
+   * @param configFile the relative path to the config file inside the repo on disk
+   * @param key the key to set in the config file
+   * @param value the value to set in the config file
+   * @returns true if the config file was updated, false otherwise
+   */
+  async config(configFile: string, key: string, value: string) {
+    const result = await execute(this.#toolPath, [
+      'config',
+      '-f',
+      this.#targetFolder.join(configFile).fsPath,
+      key,
+      value
+    ], {
+      env: this.#environment,
+      cwd: this.#targetFolder.fsPath
+    });
+    return result.code === 0 ? true : false;
   }
 }

--- a/ce/ce/artifacts/artifact.ts
+++ b/ce/ce/artifacts/artifact.ts
@@ -38,19 +38,20 @@ class ArtifactBase {
   constructor(protected session: Session, public readonly metadata: MetadataFile) {
     this.applicableDemands = new SetOfDemands(this.metadata, this.session);
     this.registries = new Registries(session);
-
-    // load the registries from the project file
-    for (const [name, registry] of this.metadata.registries) {
-      const reg = session.loadRegistry(registry.location.get(0), registry.registryKind || 'artifact');
-      if (reg) {
-        this.registries.add(reg, name);
-      }
-    }
   }
 
   /** Async Initializer */
   async init(session: Session) {
     await this.applicableDemands.init(session);
+
+    // load the registries from the project file
+    for (const [name, registry] of this.metadata.registries) {
+      const reg = await session.loadRegistry(registry.location.get(0), registry.registryKind || 'artifact');
+      if (reg) {
+        this.registries.add(reg, name);
+      }
+    }
+
     return this;
   }
 

--- a/ce/ce/cli/commands/regenerate-index.ts
+++ b/ce/ce/cli/commands/regenerate-index.ts
@@ -48,7 +48,7 @@ export class RegenerateCommand extends Command {
           // see if the name is a location
           const location = await session.parseLocation(registryNameOrLocation);
           registry = location ?
-            session.loadRegistry(location, 'artifact') :  // a folder
+            await session.loadRegistry(location, 'artifact') :  // a folder
             registries.getRegistry(registryNameOrLocation); // a registry name or other location.
         }
         if (registry) {

--- a/ce/ce/cli/switches/project.ts
+++ b/ce/ce/cli/switches/project.ts
@@ -52,7 +52,7 @@ export class Project extends Switch {
       }
 
       debug(`Loading project manifest ${project} `);
-      return new ProjectManifest(session, await session.openManifest(project));
+      return await new ProjectManifest(session, await session.openManifest(project)).init(session);
     });
   }
 }

--- a/ce/ce/cli/switches/registry.ts
+++ b/ce/ce/cli/switches/registry.ts
@@ -21,7 +21,7 @@ export class Registry extends Switch {
         const uri = session.parseUri(registry);
         if (await session.isLocalRegistry(uri) || await session.isRemoteRegistry(uri)) {
 
-          const r = session.loadRegistry(uri, 'artifact');
+          const r = await session.loadRegistry(uri, 'artifact');
           if (r) {
             try {
               await r.load();

--- a/ce/ce/fs/acquire.ts
+++ b/ce/ce/fs/acquire.ts
@@ -141,7 +141,7 @@ async function https(session: Session, uris: Array<Uri>, outputFilename: string,
           const algorithm = <Algorithm>(await locations.algorithm);
           const value = await locations.hash;
           session.channels.debug(`Acquire '${outputFilename}': remote alg/hash: '${algorithm}'/'${value}`);
-          if (algorithm && value && outputFile.hashValid(events, { algorithm, value, ...options })) {
+          if (algorithm && value && await outputFile.hashValid(events, { algorithm, value, ...options })) {
             session.channels.debug(`Acquire '${outputFilename}': on disk file hash matches the server hash`);
             // so *we* don't have the hash, but ... if the server has a hash, we could see if what we have is what they have?
             // it does match what the server has.

--- a/ce/ce/installers/git.ts
+++ b/ce/ce/installers/git.ts
@@ -23,28 +23,29 @@ export async function installGit(session: Session, name: string, targetLocation:
 
   const gitTool = new Git(session, gitPath, await session.activation.getEnvironmentBlock(), targetDirectory);
 
-  await gitTool.clone(repo, events, {
-    recursive: install.recurse,
-    depth: install.full ? undefined : 1,
-  });
+  if (! await gitTool.init()) {
+    throw new Error(i`Failed to initialize git repository folder (${targetDirectory.fsPath})`);
+  }
 
-  if (install.commit) {
-    if (install.full) {
-      await gitTool.reset(events, {
-        commit: install.commit,
-        recurse: install.recurse,
-        hard: true
-      });
+  if (!await gitTool.addRemote('origin', repo)) {
+    throw new Error(i`Failed to set git origin (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
+  }
+
+  if (!await gitTool.fetch('origin', events, { commit: install.commit, depth: install.full ? undefined : 1 })) {
+    throw new Error(i`Unable to fetch git data for (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
+  }
+
+  if (!await gitTool.checkout(events, { commit: "FETCH_HEAD" })) {
+    throw new Error(i`Unable to checkout data for (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
+  }
+
+  if (install.recurse) {
+    if (!await gitTool.config('.gitmodules', 'submodule.*.shallow', 'true')) {
+      throw new Error(i`Unable to set submodule shallow data for (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
     }
-    else {
-      await gitTool.fetch('origin', events, {
-        commit: install.commit,
-        recursive: install.recurse,
-        depth: install.full ? undefined : 1
-      });
-      await gitTool.checkout(events, {
-        commit: install.commit
-      });
+
+    if (!await gitTool.updateSubmodules(events, { init: true, recursive: true, depth: install.full ? undefined : 1 })) {
+      throw new Error(i`Unable update submodules for (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
     }
   }
 }

--- a/ce/ce/installers/git.ts
+++ b/ce/ce/installers/git.ts
@@ -24,22 +24,27 @@ export async function installGit(session: Session, name: string, targetLocation:
   const gitTool = new Git(session, gitPath, await session.activation.getEnvironmentBlock(), targetDirectory);
 
   if (! await gitTool.init()) {
+    events.heartbeat?.(i`Initializing repository folder`);
     throw new Error(i`Failed to initialize git repository folder (${targetDirectory.fsPath})`);
   }
 
   if (!await gitTool.addRemote('origin', repo)) {
+    events.heartbeat?.(i`Adding remote ${repo.toString()} to git repostory folder`);
     throw new Error(i`Failed to set git origin (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
   }
 
   if (!await gitTool.fetch('origin', events, { commit: install.commit, depth: install.full ? undefined : 1 })) {
+    events.heartbeat?.(i`Fetching remote ${repo.toString()} for git repostory folder`);
     throw new Error(i`Unable to fetch git data for (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
   }
 
   if (!await gitTool.checkout(events, { commit: "FETCH_HEAD" })) {
+    events.heartbeat?.(i`Checking out commit ${install.commit} for ${repo.toString()} to git repostory folder`);
     throw new Error(i`Unable to checkout data for (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
   }
 
   if (install.recurse) {
+    events.heartbeat?.(i`Updating submodules for repository ${repo.toString()} in the git repostory folder`);
     if (!await gitTool.config('.gitmodules', 'submodule.*.shallow', 'true')) {
       throw new Error(i`Unable to set submodule shallow data for (${repo.toString()}) in folder (${targetDirectory.fsPath})`);
     }

--- a/ce/ce/registries/RemoteRegistry.ts
+++ b/ce/ce/registries/RemoteRegistry.ts
@@ -13,7 +13,8 @@ import { Uri } from '../util/uri';
 import { ArtifactIndex } from './artifact-index';
 import { ArtifactRegistry } from './ArtifactRegistry';
 import { Index } from './indexer';
-
+import { createHash } from 'crypto';
+import { isGithubRepo } from '../util/checks';
 
 export class RemoteRegistry extends ArtifactRegistry implements Registry {
 
@@ -25,6 +26,7 @@ export class RemoteRegistry extends ArtifactRegistry implements Registry {
   constructor(session: Session, location: Uri) {
     strict.ok(location.scheme === 'https', `remote registry location must be an HTTPS uri (${location})`);
     super(session, location);
+
     this.cacheFolder = session.registryFolder.join(this.localName);
     this.indexYaml = this.cacheFolder.join(registryIndexFile);
     this.installationFolder = session.installFolder.join(this.localName);
@@ -38,13 +40,19 @@ export class RemoteRegistry extends ArtifactRegistry implements Registry {
  */
   private get localName() {
     if (!this.#localName) {
-      // if this is this a reference to a github repo, use the org/repo name
-      this.#localName = /^https:\/\/github.com\/([a-zA-Z0-9-_]*\/[a-zA-Z0-9-_]*)\/?(.*)$/gi.exec(this.location.toString())?.[1];
+      switch (this.location.authority.toLowerCase()) {
+        case 'aka.ms':
+          return this.#localName = this.location.path.replace(/\//g, '');
 
-      // if we didn't get a match, use the url to generate a local filesystem name
-      if (!this.#localName) {
-        this.#localName = this.location.toString().replace(/^[a-zA-Z0-9]*:\/*/g, '').replace(/[^a-zA-Z0-9/]/g, '_');
+        case 'github.com':
+          if (isGithubRepo(this.location)) {
+            // it's a reference to a github repo, the assumption that the zip archive is what we're getting
+            return this.#localName = this.location.path;
+          }
+          break;
       }
+      // if we didn't get a match, use the url to generate a local filesystem name
+      this.#localName = createHash('sha256').update(this.location.toString(), 'utf8').digest('hex').substring(0, 8);
     }
     return this.#localName;
   }
@@ -74,18 +82,17 @@ export class RemoteRegistry extends ArtifactRegistry implements Registry {
   async update() {
     this.session.channels.message(i`Updating registry data from ${this.location.toString()}`);
 
-    // get zip file location if
-    const ref = /^https:\/\/github.com\/([a-zA-Z0-9-_]*\/[a-zA-Z0-9-_]*\/?)$/gi.exec(this.location.toString());
     let locations = [this.location];
-    if (ref) {
+
+    if (isGithubRepo(this.location)) {
       // it's just a github uri, let's use the main/m*ster branch as the zip file location.
       locations = [this.location.join('archive/refs/heads/main.zip'), this.location.join('archive/refs/heads/master.zip')];
     }
 
-    const file = await acquireArtifactFile(this.session, [this.location], `${this.safeName}-registry.zip`, {});
+    const file = await acquireArtifactFile(this.session, locations, `${this.safeName}-registry.zip`, {});
     if (await file.exists()) {
       const unpacker = new ZipUnpacker(this.session);
-      await unpacker.unpack(file, this.cacheFolder, {}, { strip: 1 });
+      await unpacker.unpack(file, this.cacheFolder, {}, { strip: -1 });
       await file.delete();
     }
   }

--- a/ce/ce/session.ts
+++ b/ce/ce/session.ts
@@ -154,7 +154,8 @@ export class Session {
 
   async loadRegistry(registryLocation: Uri | string | undefined, registryKind = 'artifact'): Promise<Registry | undefined> {
     // normalize the location first. 
-    registryLocation = typeof registryLocation === 'string' ? await this.parseLocation(registryLocation) : registryLocation;
+
+    registryLocation = typeof registryLocation === 'string' ? await this.parseLocation(registryLocation) || this.parseUri(registryLocation) : registryLocation;
 
     if (!registryLocation) {
       return undefined;

--- a/ce/ce/util/checks.ts
+++ b/ce/ce/util/checks.ts
@@ -5,6 +5,7 @@ import { isScalar, isSeq, YAMLMap } from 'yaml';
 import { i } from '../i18n';
 import { ErrorKind } from '../interfaces/error-kind';
 import { ValidationError } from '../interfaces/validation-error';
+import { Uri } from './uri';
 
 /** @internal */
 export function isPrimitive(value: any): value is (string | number | boolean) {
@@ -66,4 +67,8 @@ export function* checkOptionalArrayOfStrings(parent: YAMLMap, range: [number, nu
   if (checkOptionalArrayOfStringsImpl(parent, range, name)) {
     yield { message: i`${name} must be an array of strings, or unset`, range: range, category: ErrorKind.IncorrectType };
   }
+}
+
+export function isGithubRepo(uri: Uri): boolean {
+  return uri.authority.toLowerCase() === 'github.com' && !!(/\/[a-zA-Z0-9-_]*\/[a-zA-Z0-9-_]*$/g.exec(uri.path));
 }


### PR DESCRIPTION
- when a registry is updated, the zip file will check to see how deep to strip off folders that should not be there 
- made registry loading async
- fix git clone to be smarter/faster 
- make the 'localname' for a repo a bit cleaner for github and aka.ms registries, otherwise generate a smaller name 


To test this:

``` powershell
# ensure we have vcpkg stable
iex (iwr -useb https://aka.ms/vcpkg-init.ps1)

#clone the blink repo
git clone https://github.com/some-example/blink
cd blink

# run the devel version of vcpkg:
C:\work\2022\vcpkg-tool\out\build\x64-Debug\vcpkg.ps1 activate
```

## output
``` text
warning: vcpkg-ce ('configure environment') is experimental and may change at any time.
Using in-development vcpkg-artifacts built at: C:/work/2022/vcpkg-tool/ce/ce
Updating registry data from https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip
Updating registry data from https://aka.ms/vcpkg-ce-default
 Artifact                                                                                                             Version                Status        Dependency  Summary
 espressif:idf                                                                                                        1.10.2                 will install  *           Espressif IDF
 microsoft:tools/kitware/cmake                                                                                        3.20.1                 will install  *           Kitware's cmake tool
 microsoft:tools/ninja-build/ninja                                                                                    1.10.2                 will install  *           Ninja is a small build system with a focus on speed.
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:ccache              4.3.0                  will install  *
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:dfu_util            0.9.0                  will install  *
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:riscv32-esp-elf     8.4.0-patch3           will install  *
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:openocd             0.11.0-esp32-20211120  will install  *
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:xtensa-esp32s2-elf  8.4.0-patch3           will install  *
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:xtensa-esp32s3-elf  8.4.0-patch3           will install  *
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:xtensa-esp32-elf    8.4.0-patch3           will install  *
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:esp32s2ulp-elf      2.28.51-esp20191205    will install  *
 [https://github.com/fearthecowboy/registries/releases/download/espressif-idf-1.10/Espressif.zip]:esp32ulp-elf        2.28.51-esp20191205    will install  *

```